### PR TITLE
docs: update CLAUDE guidance and link agents

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+CLAUDE.md
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary
- refresh CLAUDE.md to describe the current TypeScript architecture, tooling, and workflows
- add references to the dev-context documentation set for shared development standards
- symlink AGENTS.md to CLAUDE.md so both entry points stay in sync

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf39c4fbfc83279fe0d816af7fc4e2